### PR TITLE
Don't show onboarding pager to user if they have seen it in the past

### DIFF
--- a/app/src/main/java/edu/uw/covidsafe/preferences/AppPreferencesHelper.java
+++ b/app/src/main/java/edu/uw/covidsafe/preferences/AppPreferencesHelper.java
@@ -1,0 +1,23 @@
+package edu.uw.covidsafe.preferences;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+public class AppPreferencesHelper {
+
+    public static final String ONBOARDING_PAGER_SHOWN = "onboardingshownalready";
+    public static String SHARED_PREFENCE_NAME = "preferences";
+
+
+    public static final SharedPreferences getSharedPreferences(Context context) {
+        return context.getSharedPreferences(SHARED_PREFENCE_NAME, Context.MODE_PRIVATE);
+    }
+
+    public static void setOnboardingShownToUser(Context context) {
+        getSharedPreferences(context).edit().putBoolean(ONBOARDING_PAGER_SHOWN, true).apply();
+    }
+
+    public static boolean isOnboardingShownToUser(Context context) {
+        return getSharedPreferences(context).getBoolean(ONBOARDING_PAGER_SHOWN, false);
+    }
+}

--- a/app/src/main/java/edu/uw/covidsafe/ui/onboarding/OnboardingActivity.java
+++ b/app/src/main/java/edu/uw/covidsafe/ui/onboarding/OnboardingActivity.java
@@ -18,6 +18,7 @@ import com.example.covidsafe.R;
 
 import edu.uw.covidsafe.ble.BluetoothUtils;
 import edu.uw.covidsafe.comms.NetworkConstant;
+import edu.uw.covidsafe.preferences.AppPreferencesHelper;
 import edu.uw.covidsafe.ui.MainActivity;
 import edu.uw.covidsafe.ui.PermissionLogic;
 import edu.uw.covidsafe.ui.settings.PermUtils;
@@ -55,8 +56,13 @@ public class OnboardingActivity extends AppCompatActivity {
         Log.e("onboarding","should start onboarding? "+b);
         if (b || forceOnboard) {
             setContentView(R.layout.activity_onboarding);
-            getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container_onboarding,
-                    Constants.PagerFragment).commit();
+            if(AppPreferencesHelper.isOnboardingShownToUser(this)){
+                getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container_onboarding,
+                        Constants.PermissionsFragment).commit();
+            } else {
+                getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container_onboarding,
+                        Constants.PagerFragment).commit();
+            }
         }
         else {
             startActivity(new Intent(OnboardingActivity.this, MainActivity.class));

--- a/app/src/main/java/edu/uw/covidsafe/ui/onboarding/PagerFragment.java
+++ b/app/src/main/java/edu/uw/covidsafe/ui/onboarding/PagerFragment.java
@@ -18,6 +18,7 @@ import androidx.viewpager.widget.ViewPager;
 
 import com.example.covidsafe.R;
 
+import edu.uw.covidsafe.preferences.AppPreferencesHelper;
 import edu.uw.covidsafe.ui.MainActivity;
 import edu.uw.covidsafe.utils.Constants;
 
@@ -43,6 +44,23 @@ public class PagerFragment extends Fragment {
         if (Constants.pageNumber != -1) {
             viewPager.setCurrentItem(Constants.pageNumber);
         }
+        viewPager.addOnPageChangeListener(new ViewPager.OnPageChangeListener() {
+            @Override
+            public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+
+            }
+
+            @Override
+            public void onPageSelected(int position) {
+                    if(position == 3){
+                        AppPreferencesHelper.setOnboardingShownToUser(getActivity());
+                    }
+            }
+
+            @Override
+            public void onPageScrollStateChanged(int state) {
+            }
+        });
         return view;
     }
 


### PR DESCRIPTION
We don't want to show the same page to the user if they have seen and scrolled through it once. Generally not considered as a good UX. 