### PR TITLE
[Do not Review]Move all bluetooth status flag value to one source of truth

### DIFF
--- a/app/src/main/java/edu/uw/covidsafe/LoggingService.java
+++ b/app/src/main/java/edu/uw/covidsafe/LoggingService.java
@@ -23,6 +23,7 @@ import com.example.covidsafe.R;
 import edu.uw.covidsafe.ble.BluetoothServerHelper;
 import edu.uw.covidsafe.ble.BluetoothUtils;
 import edu.uw.covidsafe.gps.GpsUtils;
+import edu.uw.covidsafe.preferences.AppPreferencesHelper;
 import edu.uw.covidsafe.ui.MainActivity;
 import edu.uw.covidsafe.utils.Constants;
 import edu.uw.covidsafe.utils.Utils;
@@ -67,7 +68,7 @@ public class LoggingService extends IntentService {
         Log.e("ex","bundle status "+(bundle==null));
 
         SharedPreferences prefs = getApplicationContext().getSharedPreferences(Constants.SHARED_PREFENCE_NAME, Context.MODE_PRIVATE);
-        boolean bleEnabled = prefs.getBoolean(getApplicationContext().getString(R.string.ble_enabled_pkey), Constants.BLUETOOTH_ENABLED);
+        boolean bleEnabled = AppPreferencesHelper.isBluetoothEnabled(getApplicationContext());
         boolean gpsEnabled = prefs.getBoolean(getApplicationContext().getString(R.string.gps_enabled_pkey), Constants.GPS_ENABLED);
 
         if (bleEnabled) {

--- a/app/src/main/java/edu/uw/covidsafe/LoggingService.java
+++ b/app/src/main/java/edu/uw/covidsafe/LoggingService.java
@@ -22,6 +22,7 @@ import com.example.covidsafe.R;
 
 import edu.uw.covidsafe.ble.BluetoothServerHelper;
 import edu.uw.covidsafe.ble.BluetoothUtils;
+import edu.uw.covidsafe.crypto.Constant;
 import edu.uw.covidsafe.gps.GpsUtils;
 import edu.uw.covidsafe.preferences.AppPreferencesHelper;
 import edu.uw.covidsafe.ui.MainActivity;
@@ -68,7 +69,7 @@ public class LoggingService extends IntentService {
         Log.e("ex","bundle status "+(bundle==null));
 
         SharedPreferences prefs = getApplicationContext().getSharedPreferences(Constants.SHARED_PREFENCE_NAME, Context.MODE_PRIVATE);
-        boolean bleEnabled = AppPreferencesHelper.isBluetoothEnabled(getApplicationContext());
+        boolean bleEnabled = AppPreferencesHelper.isBluetoothEnabled(getApplicationContext(), Constants.BLUETOOTH_ENABLED);
         boolean gpsEnabled = prefs.getBoolean(getApplicationContext().getString(R.string.gps_enabled_pkey), Constants.GPS_ENABLED);
 
         if (bleEnabled) {

--- a/app/src/main/java/edu/uw/covidsafe/ble/BluetoothUtils.java
+++ b/app/src/main/java/edu/uw/covidsafe/ble/BluetoothUtils.java
@@ -17,6 +17,7 @@ import android.util.Log;
 
 import com.example.covidsafe.R;
 
+import edu.uw.covidsafe.preferences.AppPreferencesHelper;
 import edu.uw.covidsafe.seed_uuid.UUIDGeneratorTask;
 import edu.uw.covidsafe.utils.ByteUtils;
 import edu.uw.covidsafe.utils.Constants;
@@ -57,8 +58,7 @@ public class BluetoothUtils {
                     if (Constants.LoggingServiceRunning) {
                         BluetoothUtils.haltBle(context);
                     }
-                    editor.putBoolean(context.getString(R.string.ble_enabled_pkey), false);
-                    editor.commit();
+                    AppPreferencesHelper.setBluetoothEnabled(context,false);
                     if (Constants.bleSwitch != null) {
                         Constants.bleSwitch.setChecked(false);
                     }
@@ -77,8 +77,7 @@ public class BluetoothUtils {
                     }
 
                     if (Utils.hasBlePermissions(context)){
-                        editor.putBoolean(context.getString(R.string.ble_enabled_pkey), true);
-                        editor.commit();
+                        AppPreferencesHelper.setBluetoothEnabled(context);
                         if (Constants.bleSwitch != null) {
                             Constants.bleSwitch.setChecked(true);
                         }
@@ -165,7 +164,7 @@ public class BluetoothUtils {
 
     public static void mkBeacon(Context context) {
         SharedPreferences prefs = context.getSharedPreferences(Constants.SHARED_PREFENCE_NAME, Context.MODE_PRIVATE);
-        boolean bleEnabled = prefs.getBoolean(context.getString(R.string.ble_enabled_pkey), false);
+        boolean bleEnabled = AppPreferencesHelper.isBluetoothEnabled(context);
         Log.e("ble","mkbeacon "+bleEnabled);
         Log.e("bledebug","mkbeacon contactUUID "+Constants.contactUUID);
         if (bleEnabled) {

--- a/app/src/main/java/edu/uw/covidsafe/preferences/AppPreferencesHelper.java
+++ b/app/src/main/java/edu/uw/covidsafe/preferences/AppPreferencesHelper.java
@@ -3,10 +3,15 @@ package edu.uw.covidsafe.preferences;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import edu.uw.covidsafe.crypto.Constant;
+import edu.uw.covidsafe.utils.Constants;
+
 public class AppPreferencesHelper {
 
     public static final String ONBOARDING_PAGER_SHOWN = "onboardingshownalready";
+    public static final String BLUETOOTH_ENABLED = "bleEnabled";
     public static String SHARED_PREFENCE_NAME = "preferences";
+
 
 
     public static final SharedPreferences getSharedPreferences(Context context) {
@@ -19,5 +24,17 @@ public class AppPreferencesHelper {
 
     public static boolean isOnboardingShownToUser(Context context) {
         return getSharedPreferences(context).getBoolean(ONBOARDING_PAGER_SHOWN, false);
+    }
+
+    public static void setBluetoothEnabled(Context context) {
+        setBluetoothEnabled(context, true);
+    }
+
+    public static boolean isBluetoothEnabled(Context context) {
+        return getSharedPreferences(context).getBoolean(ONBOARDING_PAGER_SHOWN, Constants.BLUETOOTH_ENABLED);
+    }
+
+    public static void setBluetoothEnabled(Context context, boolean bleFlagVal) {
+        getSharedPreferences(context).edit().putBoolean(BLUETOOTH_ENABLED, bleFlagVal);
     }
 }

--- a/app/src/main/java/edu/uw/covidsafe/preferences/AppPreferencesHelper.java
+++ b/app/src/main/java/edu/uw/covidsafe/preferences/AppPreferencesHelper.java
@@ -31,7 +31,7 @@ public class AppPreferencesHelper {
     }
 
     public static boolean isBluetoothEnabled(Context context) {
-        return getSharedPreferences(context).getBoolean(ONBOARDING_PAGER_SHOWN, Constants.BLUETOOTH_ENABLED);
+        return getSharedPreferences(context).getBoolean(BLUETOOTH_ENABLED, Constants.BLUETOOTH_ENABLED);
     }
 
     public static void setBluetoothEnabled(Context context, boolean bleFlagVal) {

--- a/app/src/main/java/edu/uw/covidsafe/preferences/AppPreferencesHelper.java
+++ b/app/src/main/java/edu/uw/covidsafe/preferences/AppPreferencesHelper.java
@@ -31,7 +31,11 @@ public class AppPreferencesHelper {
     }
 
     public static boolean isBluetoothEnabled(Context context) {
-        return getSharedPreferences(context).getBoolean(BLUETOOTH_ENABLED, Constants.BLUETOOTH_ENABLED);
+        return getSharedPreferences(context).getBoolean(BLUETOOTH_ENABLED, false);
+    }
+
+    public static boolean isBluetoothEnabled(Context context, boolean defaultFlag) {
+        return getSharedPreferences(context).getBoolean(BLUETOOTH_ENABLED, defaultFlag);
     }
 
     public static void setBluetoothEnabled(Context context, boolean bleFlagVal) {

--- a/app/src/main/java/edu/uw/covidsafe/ui/MainActivity.java
+++ b/app/src/main/java/edu/uw/covidsafe/ui/MainActivity.java
@@ -18,6 +18,7 @@ import android.view.View;
 import androidx.fragment.app.FragmentTransaction;
 import edu.uw.covidsafe.ble.BluetoothUtils;
 import edu.uw.covidsafe.comms.NetworkConstant;
+import edu.uw.covidsafe.preferences.AppPreferencesHelper;
 import edu.uw.covidsafe.ui.health.TipRecyclerViewAdapter;
 import edu.uw.covidsafe.ui.notif.HistoryRecyclerViewAdapter;
 import edu.uw.covidsafe.ui.notif.NotifRecyclerViewAdapter;
@@ -115,9 +116,7 @@ public class MainActivity extends AppCompatActivity {
         if (requestCode == 0) {
             if (resultCode == -1) {
                 if (hasBlePerms) {
-                    SharedPreferences.Editor editor = getApplicationContext().getSharedPreferences(Constants.SHARED_PREFENCE_NAME, Context.MODE_PRIVATE).edit();
-                    editor.putBoolean(getApplicationContext().getString(R.string.ble_enabled_pkey), true);
-                    editor.commit();
+                    AppPreferencesHelper.setBluetoothEnabled(this);
                     if (!Constants.LoggingServiceRunning) {
                         Utils.startLoggingService(this);
                         Log.e("ble","ble switch logic");
@@ -148,7 +147,7 @@ public class MainActivity extends AppCompatActivity {
         if (!Constants.LoggingServiceRunning) {
             SharedPreferences prefs = getSharedPreferences(Constants.SHARED_PREFENCE_NAME, Context.MODE_PRIVATE);
             boolean gpsEnabled = prefs.getBoolean(getString(R.string.gps_enabled_pkey), false);
-            boolean bleEnabled = prefs.getBoolean(getString(R.string.ble_enabled_pkey), false);
+            boolean bleEnabled = AppPreferencesHelper.isBluetoothEnabled(this);
             if (gpsEnabled) {
                 PermUtils.gpsSwitchLogic(this);
             }

--- a/app/src/main/java/edu/uw/covidsafe/ui/MainFragment.java
+++ b/app/src/main/java/edu/uw/covidsafe/ui/MainFragment.java
@@ -39,6 +39,7 @@ import edu.uw.covidsafe.comms.PullFromServerTask;
 import edu.uw.covidsafe.comms.PullFromServerTaskDemo;
 import edu.uw.covidsafe.comms.PullFromServerTaskDemo2;
 import edu.uw.covidsafe.hcp.SubmitNarrowcastMessageTask;
+import edu.uw.covidsafe.preferences.AppPreferencesHelper;
 import edu.uw.covidsafe.ui.health.ResourceRecyclerViewAdapter;
 import edu.uw.covidsafe.ui.notif.NotifDbModel;
 import edu.uw.covidsafe.ui.notif.NotifOpsAsyncTask;
@@ -177,7 +178,7 @@ public class MainFragment extends Fragment {
             public void onClick(View v) {
                 SharedPreferences prefs = getActivity().getSharedPreferences(Constants.SHARED_PREFENCE_NAME, Context.MODE_PRIVATE);
                 boolean gpsEnabled = prefs.getBoolean(getActivity().getString(R.string.gps_enabled_pkey), false);
-                boolean bleEnabled = prefs.getBoolean(getActivity().getString(R.string.ble_enabled_pkey), false);
+                boolean bleEnabled = AppPreferencesHelper.isBluetoothEnabled(getContext());
 
                 // flip switch to inverse of current broadcasting state
                 broadcastSwitchLogic(!(gpsEnabled||bleEnabled));
@@ -261,7 +262,7 @@ public class MainFragment extends Fragment {
         SharedPreferences.Editor editor = prefs.edit();
 
         boolean gpsEnabled = prefs.getBoolean(getActivity().getString(R.string.gps_enabled_pkey), false);
-        boolean bleEnabled = prefs.getBoolean(getActivity().getString(R.string.ble_enabled_pkey), false);
+        boolean bleEnabled = AppPreferencesHelper.isBluetoothEnabled(getActivity());
 
         if (!hasGpsPerms) {
             Log.e("state","no gps");
@@ -270,14 +271,13 @@ public class MainFragment extends Fragment {
         }
         if (!hasBlePerms) {
             Log.e("state","no ble");
-            editor.putBoolean(getActivity().getString(R.string.ble_enabled_pkey), false);
-            editor.commit();
+            AppPreferencesHelper.setBluetoothEnabled(getActivity(), false);
         }
 
         if ((!hasGpsPerms && !hasBlePerms) || (!gpsEnabled && !bleEnabled)) {
             Log.e("state","no perms");
             editor.putBoolean(getActivity().getString(R.string.gps_enabled_pkey), false);
-            editor.putBoolean(getActivity().getString(R.string.ble_enabled_pkey), false);
+            AppPreferencesHelper.setBluetoothEnabled(getActivity(), false);
             editor.commit();
 
             if (animate) {

--- a/app/src/main/java/edu/uw/covidsafe/ui/PermissionLogic.java
+++ b/app/src/main/java/edu/uw/covidsafe/ui/PermissionLogic.java
@@ -20,6 +20,7 @@ import androidx.core.app.ActivityCompat;
 import com.example.covidsafe.R;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
+import edu.uw.covidsafe.preferences.AppPreferencesHelper;
 import edu.uw.covidsafe.ui.settings.PermissionsRecyclerViewAdapter;
 import edu.uw.covidsafe.utils.Constants;
 import edu.uw.covidsafe.utils.Utils;
@@ -69,9 +70,8 @@ public class PermissionLogic {
                 } else if (!shouldAsk) {
                     // preemptively add it
                     if (requestCode == 1) {
-                        editor.putBoolean(av.getString(R.string.ble_enabled_pkey), true);
+                        AppPreferencesHelper.setBluetoothEnabled(av);
                         Log.e("perm", "ble preemptive set " +true);
-                        editor.commit();
                     }
                     else if (requestCode == 2) {
                         editor.putBoolean(av.getString(R.string.gps_enabled_pkey), true);
@@ -88,7 +88,7 @@ public class PermissionLogic {
                     Log.e("perms","gps enabled");
                 }
                 else if (requestCode == 1) {
-                    editor.putBoolean(av.getString(R.string.ble_enabled_pkey), true);
+                    AppPreferencesHelper.setBluetoothEnabled(av);
                     Log.e("perms","ble enabled");
                 }
                 editor.commit();
@@ -130,8 +130,7 @@ public class PermissionLogic {
                                 Constants.bleSwitch.setChecked (false);
 //                                Constants.bleSwitch.setOnCheckedChangeListener (PermUtil.listener);
                                 Log.e("perms","ble set false");
-                                editor.putBoolean(av.getString(R.string.ble_enabled_pkey), false);
-                                editor.commit();
+                                AppPreferencesHelper.setBluetoothEnabled(av, false);
                             }
                         }
                     }})
@@ -176,8 +175,7 @@ public class PermissionLogic {
 //                                Constants.bleSwitch.setOnCheckedChangeListener (null);
                                 Constants.bleSwitch.setChecked (false);
 //                                Constants.bleSwitch.setOnCheckedChangeListener (PermUtil.listener);
-                                editor.putBoolean(av.getString(R.string.ble_enabled_pkey), false);
-                                editor.commit();
+                                AppPreferencesHelper.setBluetoothEnabled(av, false);
                             }
                         }
                     }

--- a/app/src/main/java/edu/uw/covidsafe/ui/onboarding/OnboardingActivity.java
+++ b/app/src/main/java/edu/uw/covidsafe/ui/onboarding/OnboardingActivity.java
@@ -114,8 +114,7 @@ public class OnboardingActivity extends AppCompatActivity {
             if (resultCode == -1) {
                 if (hasBlePerms) {
                     SharedPreferences.Editor editor = getApplicationContext().getSharedPreferences(Constants.SHARED_PREFENCE_NAME, Context.MODE_PRIVATE).edit();
-                    editor.putBoolean(getApplicationContext().getString(R.string.ble_enabled_pkey), true);
-                    editor.commit();
+                    AppPreferencesHelper.setBluetoothEnabled(this);
                     if (!Constants.LoggingServiceRunning) {
                         Utils.startLoggingService(this);
                         Log.e("ble","ble switch logic");

--- a/app/src/main/java/edu/uw/covidsafe/ui/onboarding/PermissionFragment.java
+++ b/app/src/main/java/edu/uw/covidsafe/ui/onboarding/PermissionFragment.java
@@ -37,6 +37,7 @@ import com.example.covidsafe.R;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
 import edu.uw.covidsafe.ble.BluetoothUtils;
+import edu.uw.covidsafe.preferences.AppPreferencesHelper;
 import edu.uw.covidsafe.ui.MainActivity;
 import edu.uw.covidsafe.ui.settings.PermissionsRecyclerViewAdapter;
 import edu.uw.covidsafe.utils.Constants;
@@ -94,7 +95,7 @@ public class PermissionFragment extends Fragment {
                 SharedPreferences prefs = getActivity().getSharedPreferences(Constants.SHARED_PREFENCE_NAME, Context.MODE_PRIVATE);
                 boolean s1 = prefs.getBoolean(getString(R.string.notifs_enabled_pkey), false);
                 boolean s2 = prefs.getBoolean(getString(R.string.gps_enabled_pkey), false);
-                boolean s3 = prefs.getBoolean(getString(R.string.ble_enabled_pkey), false);
+                boolean s3 = AppPreferencesHelper.isBluetoothEnabled(getActivity());
                 Log.e("perms","PERM STATE "+s1+","+s2+","+s3);
             }
         });

--- a/app/src/main/java/edu/uw/covidsafe/ui/settings/PermUtils.java
+++ b/app/src/main/java/edu/uw/covidsafe/ui/settings/PermUtils.java
@@ -24,6 +24,7 @@ import com.example.covidsafe.R;
 
 import edu.uw.covidsafe.ble.BluetoothUtils;
 import edu.uw.covidsafe.gps.GpsUtils;
+import edu.uw.covidsafe.preferences.AppPreferencesHelper;
 import edu.uw.covidsafe.utils.Constants;
 import edu.uw.covidsafe.utils.Utils;
 
@@ -69,8 +70,7 @@ public class PermUtils {
         boolean hasBle = Utils.hasBlePermissions(av);
 
         if (hasBle && BluetoothUtils.isBluetoothOn(av)) {
-            editor.putBoolean(av.getString(R.string.ble_enabled_pkey), true);
-            editor.commit();
+            AppPreferencesHelper.setBluetoothEnabled(av);
             if (!Constants.LoggingServiceRunning) {
                 Utils.startLoggingService(av);
                 Log.e("ble","ble switch logic");

--- a/app/src/main/java/edu/uw/covidsafe/ui/settings/PermissionsRecyclerViewAdapter.java
+++ b/app/src/main/java/edu/uw/covidsafe/ui/settings/PermissionsRecyclerViewAdapter.java
@@ -178,7 +178,7 @@ public class PermissionsRecyclerViewAdapter extends RecyclerView.Adapter<Recycle
                         PermUtils.bleSwitchLogic(av);
                     }
                     else {
-                        AppPreferencesHelper.setBluetoothEnabled(av, false);
+                        AppPreferencesHelper.setBluetoothEnabled(av, Constants.BLUETOOTH_ENABLED);
                         BluetoothUtils.haltBle(av);
                         // ble and gps are turned off, halt
                         if (!Constants.gpsSwitch.isChecked()) {

--- a/app/src/main/java/edu/uw/covidsafe/ui/settings/PermissionsRecyclerViewAdapter.java
+++ b/app/src/main/java/edu/uw/covidsafe/ui/settings/PermissionsRecyclerViewAdapter.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 
 import edu.uw.covidsafe.ble.BluetoothUtils;
 import edu.uw.covidsafe.gps.GpsUtils;
+import edu.uw.covidsafe.preferences.AppPreferencesHelper;
 import edu.uw.covidsafe.utils.Constants;
 import edu.uw.covidsafe.utils.Utils;
 
@@ -108,18 +109,16 @@ public class PermissionsRecyclerViewAdapter extends RecyclerView.Adapter<Recycle
             if (!BluetoothUtils.checkBluetoothSupport(av)) {
                 ((PermissionCard)holder).sw.setEnabled(false);
                 ((PermissionCard)holder).desc.setText("Bluetooth is disabled on this device");
-                editor.putBoolean(cxt.getString(R.string.ble_enabled_pkey), false);
-                editor.commit();
+                AppPreferencesHelper.setBluetoothEnabled(av, false);
             }
             else if (!BluetoothUtils.isBluetoothOn(av)) {
                 ((PermissionCard)holder).desc.setText(cxt.getString(R.string.bluetooth_is_off));
-                editor.putBoolean(cxt.getString(R.string.ble_enabled_pkey), false);
-                editor.commit();
+                AppPreferencesHelper.setBluetoothEnabled(av, false);
             }
             else {
                 ((PermissionCard)holder).sw.setEnabled(true);
                 boolean hasBlePerms = Utils.hasBlePermissions(cxt);
-                boolean bleEnabled = prefs.getBoolean(cxt.getString(R.string.ble_enabled_pkey), Constants.BLUETOOTH_ENABLED);
+                boolean bleEnabled = AppPreferencesHelper.isBluetoothEnabled(cxt);
                 Log.e("perm", "ble get " + hasBlePerms + "," + bleEnabled);
                 if (hasBlePerms && bleEnabled) {
 //                ((PermissionCard)holder).sw.setOnCheckedChangeListener (null);
@@ -179,8 +178,7 @@ public class PermissionsRecyclerViewAdapter extends RecyclerView.Adapter<Recycle
                         PermUtils.bleSwitchLogic(av);
                     }
                     else {
-                        editor.putBoolean(av.getString(R.string.ble_enabled_pkey), false);
-                        editor.commit();
+                        AppPreferencesHelper.setBluetoothEnabled(av, false);
                         BluetoothUtils.haltBle(av);
                         // ble and gps are turned off, halt
                         if (!Constants.gpsSwitch.isChecked()) {

--- a/app/src/main/java/edu/uw/covidsafe/utils/Constants.java
+++ b/app/src/main/java/edu/uw/covidsafe/utils/Constants.java
@@ -222,7 +222,7 @@ public class Constants {
         }
 
         SharedPreferences prefs = av.getSharedPreferences(Constants.SHARED_PREFENCE_NAME, Context.MODE_PRIVATE);
-        Constants.BLUETOOTH_ENABLED = AppPreferencesHelper.isBluetoothEnabled(av);
+        Constants.BLUETOOTH_ENABLED = AppPreferencesHelper.isBluetoothEnabled(av, Constants.BLUETOOTH_ENABLED);
         Constants.GPS_ENABLED = prefs.getBoolean(av.getString(R.string.gps_enabled_pkey), Constants.GPS_ENABLED);
         Constants.NOTIFS_ENABLED = prefs.getBoolean(av.getString(R.string.notifs_enabled_pkey), Constants.NOTIFS_ENABLED);
     }

--- a/app/src/main/java/edu/uw/covidsafe/utils/Constants.java
+++ b/app/src/main/java/edu/uw/covidsafe/utils/Constants.java
@@ -15,6 +15,7 @@ import androidx.fragment.app.Fragment;
 
 import com.example.covidsafe.R;
 
+import edu.uw.covidsafe.preferences.AppPreferencesHelper;
 import edu.uw.covidsafe.ui.MainFragment;
 import edu.uw.covidsafe.ui.health.TipRecyclerViewAdapter;
 import edu.uw.covidsafe.ui.notif.HistoryRecyclerViewAdapter;
@@ -221,7 +222,7 @@ public class Constants {
         }
 
         SharedPreferences prefs = av.getSharedPreferences(Constants.SHARED_PREFENCE_NAME, Context.MODE_PRIVATE);
-        Constants.BLUETOOTH_ENABLED = prefs.getBoolean(av.getString(R.string.ble_enabled_pkey), Constants.BLUETOOTH_ENABLED);
+        Constants.BLUETOOTH_ENABLED = AppPreferencesHelper.isBluetoothEnabled(av);
         Constants.GPS_ENABLED = prefs.getBoolean(av.getString(R.string.gps_enabled_pkey), Constants.GPS_ENABLED);
         Constants.NOTIFS_ENABLED = prefs.getBoolean(av.getString(R.string.notifs_enabled_pkey), Constants.NOTIFS_ENABLED);
     }

--- a/app/src/main/java/edu/uw/covidsafe/utils/Utils.java
+++ b/app/src/main/java/edu/uw/covidsafe/utils/Utils.java
@@ -46,6 +46,7 @@ import edu.uw.covidsafe.ble.BluetoothUtils;
 import edu.uw.covidsafe.gps.GpsOpsAsyncTask;
 import edu.uw.covidsafe.gps.GpsRecord;
 import edu.uw.covidsafe.gps.GpsUtils;
+import edu.uw.covidsafe.preferences.AppPreferencesHelper;
 import edu.uw.covidsafe.symptoms.SymptomsRecord;
 import edu.uw.covidsafe.seed_uuid.SeedUUIDRecord;
 import com.google.android.material.snackbar.Snackbar;
@@ -86,7 +87,7 @@ public class Utils {
         SharedPreferences prefs = av.getSharedPreferences(Constants.SHARED_PREFENCE_NAME, Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = prefs.edit();
         editor.putBoolean(av.getString(R.string.gps_enabled_pkey), false);
-        editor.putBoolean(av.getString(R.string.ble_enabled_pkey), false);
+        AppPreferencesHelper.setBluetoothEnabled(av,false);
         editor.commit();
     }
 
@@ -130,9 +131,7 @@ public class Utils {
 //                Constants.bleSwitch.setOnCheckedChangeListener (null);
                 Constants.bleSwitch.setChecked (false);
 //                Constants.bleSwitch.setOnCheckedChangeListener (PermUtil.listener);
-
-                editor.putBoolean(av.getString(R.string.ble_enabled_pkey), false);
-                editor.commit();
+                AppPreferencesHelper.setBluetoothEnabled(av, false);
             }
         }
     }


### PR DESCRIPTION
It seems that the shared preferences are all over the code, which might cause issue once the codebase starts to increase, especially in debugging issues as in where the flags were changes. With this PR we have all the BLE flags in one place. 

Will put up another PR for gps flag and after this we will have a clean structure for this part of the codebase. :)